### PR TITLE
Fix category indexer fetching children from wrong table

### DIFF
--- a/src/Content/BlogCategory/BlogCategoryIndexer.php
+++ b/src/Content/BlogCategory/BlogCategoryIndexer.php
@@ -133,7 +133,7 @@ class BlogCategoryIndexer extends EntityIndexer
     {
         $query = $this->connection->createQueryBuilder();
         $query->select('DISTINCT LOWER(HEX(category.id))');
-        $query->from('category');
+        $query->from('werkl_blog_category', 'category');
 
         $wheres = [];
         foreach ($categoryIds as $id) {


### PR DESCRIPTION
The blog category indexer currently fetches category children from the Shopware default `category` table instead of the `werkl_blog_category` table.