### PR TITLE
Make teaser image translatable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ src/Resources/app/administration/coverage
 src/Resources/app/administration/node_modules
 
 ## other stuff
+/.vscode
 /.idea
 /vendor
 composer.lock

--- a/src/Content/Blog/Aggregate/BlogEntriesTagMappingDefinition.php
+++ b/src/Content/Blog/Aggregate/BlogEntriesTagMappingDefinition.php
@@ -12,7 +12,6 @@ use Shopware\Core\Framework\DataAbstractionLayer\MappingEntityDefinition;
 use Shopware\Core\System\Tag\TagDefinition;
 use Werkl\OpenBlogware\Content\Blog\BlogEntriesDefinition;
 
-
 class BlogEntriesTagMappingDefinition extends MappingEntityDefinition
 {
     public const ENTITY_NAME = 'werkl_blog_entries_tag';

--- a/src/Content/Blog/BlogEntitiesIndexer.php
+++ b/src/Content/Blog/BlogEntitiesIndexer.php
@@ -49,6 +49,10 @@ class BlogEntitiesIndexer extends EntityIndexer
     {
         $ids = $message->getData();
 
+        if (!\is_array($ids)) {
+            return;
+        }
+
         $ids = array_unique(array_filter($ids));
         if (empty($ids)) {
             return;

--- a/src/Content/Blog/BlogEntriesDefinition.php
+++ b/src/Content/Blog/BlogEntriesDefinition.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace Werkl\OpenBlogware\Content\Blog;
 
 use Shopware\Core\Content\Cms\CmsPageDefinition;
-use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\BoolField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\DateField;
@@ -60,13 +59,11 @@ class BlogEntriesDefinition extends EntityDefinition
             (new BoolField('active', 'active'))->addFlags(new ApiAware()),
             (new BoolField('detail_teaser_image', 'detailTeaserImage'))->addFlags(new ApiAware()),
 
-            new FkField('media_id', 'mediaId', MediaDefinition::class),
             (new FkField('author_id', 'authorId', BlogAuthorDefinition::class))->addFlags(new Required()),
             (new FkField('cms_page_id', 'cmsPageId', CmsPageDefinition::class))->addFlags(new ApiAware(), new Inherited()),
             (new ReferenceVersionField(CmsPageDefinition::class))->addFlags(new PrimaryKey(), new Required()),
 
-            (new OneToOneAssociationField('media', 'media_id', 'id', MediaDefinition::class, true))->addFlags(new ApiAware()),
-
+            (new TranslatedField('mediaId'))->addFlags(new ApiAware()),
             (new TranslatedField('title'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new TranslatedField('slug'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),
             (new TranslatedField('teaser'))->addFlags(new ApiAware(), new SearchRanking(SearchRanking::HIGH_SEARCH_RANKING)),

--- a/src/Content/Blog/BlogEntriesEntity.php
+++ b/src/Content/Blog/BlogEntriesEntity.php
@@ -48,7 +48,7 @@ class BlogEntriesEntity extends Entity
 
     protected ?BlogAuthorEntity $blogAuthor;
 
-    protected string $mediaId;
+    protected ?string $mediaId;
 
     protected ?MediaEntity $media;
 
@@ -58,9 +58,6 @@ class BlogEntriesEntity extends Entity
 
     protected ?CmsPageEntity $cmsPage;
 
-    /**
-     * @var TagCollection|null
-     */
     protected ?TagCollection $tags = null;
 
     public function getTitle(): ?string
@@ -193,12 +190,12 @@ class BlogEntriesEntity extends Entity
         $this->publishedAt = $publishedAt;
     }
 
-    public function getMediaId(): string
+    public function getMediaId(): ?string
     {
         return $this->mediaId;
     }
 
-    public function setMediaId(string $mediaId): void
+    public function setMediaId(?string $mediaId): void
     {
         $this->mediaId = $mediaId;
     }
@@ -233,17 +230,11 @@ class BlogEntriesEntity extends Entity
         $this->cmsPageId = $cmsPageId;
     }
 
-    /**
-     * @return TagCollection|null
-     */
     public function getTags(): ?TagCollection
     {
         return $this->tags;
     }
 
-    /**
-     * @param TagCollection|null $tags
-     */
     public function setTags(?TagCollection $tags): void
     {
         $this->tags = $tags;

--- a/src/Content/Blog/BlogEntriesTranslation/BlogEntriesTranslationDefinition.php
+++ b/src/Content/Blog/BlogEntriesTranslation/BlogEntriesTranslationDefinition.php
@@ -3,8 +3,10 @@ declare(strict_types=1);
 
 namespace Werkl\OpenBlogware\Content\Blog\BlogEntriesTranslation;
 
+use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityTranslationDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\CustomFields;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\FkField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\AllowHtml;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
@@ -40,6 +42,7 @@ class BlogEntriesTranslationDefinition extends EntityTranslationDefinition
     protected function defineFields(): FieldCollection
     {
         return new FieldCollection([
+            new FkField('media_id', 'mediaId', MediaDefinition::class),
             (new StringField('title', 'title'))->addFlags(new Required()),
             (new StringField('slug', 'slug'))->addFlags(new Required()),
             new StringField('teaser', 'teaser'),

--- a/src/Content/Blog/BlogEntriesTranslation/BlogEntriesTranslationEntity.php
+++ b/src/Content/Blog/BlogEntriesTranslation/BlogEntriesTranslationEntity.php
@@ -15,6 +15,8 @@ class BlogEntriesTranslationEntity extends TranslationEntity
 
     protected BlogEntriesEntity $werklBlogEntries;
 
+    protected ?string $mediaId;
+
     protected string $title;
 
     protected string $slug;
@@ -45,6 +47,16 @@ class BlogEntriesTranslationEntity extends TranslationEntity
     public function setWerklBlogEntries(BlogEntriesEntity $werklBlogEntries): void
     {
         $this->werklBlogEntries = $werklBlogEntries;
+    }
+
+    public function getMediaId(): ?string
+    {
+        return $this->mediaId;
+    }
+
+    public function setMediaId(?string $mediaId): void
+    {
+        $this->mediaId = $mediaId;
     }
 
     public function getTitle(): ?string

--- a/src/Content/Blog/BlogSeoUrlRoute.php
+++ b/src/Content/Blog/BlogSeoUrlRoute.php
@@ -40,7 +40,7 @@ class BlogSeoUrlRoute implements SeoUrlRouteInterface
         $criteria->addAssociations([
             'blogCategories',
             'blogAuthor',
-            'tags'
+            'tags',
         ]);
     }
 

--- a/src/Content/Blog/DataResolver/BlogCmsElementResolver.php
+++ b/src/Content/Blog/DataResolver/BlogCmsElementResolver.php
@@ -60,7 +60,7 @@ class BlogCmsElementResolver extends AbstractCmsElementResolver
             'blogAuthor.media',
             'blogAuthor.blogEntries',
             'blogCategories',
-            'tags'
+            'tags',
         ]);
 
         $criteria->addSorting(

--- a/src/Content/BlogCategory/BlogCategoryIndexer.php
+++ b/src/Content/BlogCategory/BlogCategoryIndexer.php
@@ -101,6 +101,10 @@ class BlogCategoryIndexer extends EntityIndexer
     {
         $ids = $message->getData();
 
+        if (!\is_array($ids)) {
+            return;
+        }
+
         $ids = array_unique(array_filter($ids));
         if (empty($ids)) {
             return;

--- a/src/Content/Extension/MediaExtension.php
+++ b/src/Content/Extension/MediaExtension.php
@@ -7,7 +7,7 @@ use Shopware\Core\Content\Media\MediaDefinition;
 use Shopware\Core\Framework\DataAbstractionLayer\EntityExtension;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\FieldCollection;
-use Werkl\OpenBlogware\Content\Blog\BlogEntriesDefinition;
+use Werkl\OpenBlogware\Content\Blog\BlogEntriesTranslation\BlogEntriesTranslationDefinition;
 use Werkl\OpenBlogware\Content\BlogAuthor\BlogAuthorDefinition;
 
 class MediaExtension extends EntityExtension
@@ -15,7 +15,7 @@ class MediaExtension extends EntityExtension
     public function extendFields(FieldCollection $collection): void
     {
         $collection->add(
-            new OneToOneAssociationField('blogEntries', 'id', 'media_id', BlogEntriesDefinition::class, false),
+            new OneToOneAssociationField('blogEntriesTranslation', 'id', 'media_id', BlogEntriesTranslationDefinition::class, false),
         );
         $collection->add(
             new OneToOneAssociationField('blogAuthor', 'id', 'media_id', BlogAuthorDefinition::class, false),

--- a/src/Migration/Migration1736010505Tags.php
+++ b/src/Migration/Migration1736010505Tags.php
@@ -25,7 +25,8 @@ class Migration1736010505Tags extends MigrationStep
                 CONSTRAINT `fk.werkl_blog_entries_tag.werkl_blog_entries_id` FOREIGN KEY (`werkl_blog_entries_id`) REFERENCES `werkl_blog_entries` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
                 CONSTRAINT `fk.werkl_blog_entries_tag.tag_id` FOREIGN KEY (`tag_id`) REFERENCES `tag` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
             ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
-        ');    }
+        ');
+    }
 
     public function updateDestructive(Connection $connection): void
     {

--- a/src/Migration/Migration1744229687TranslatableTeaserImage.php
+++ b/src/Migration/Migration1744229687TranslatableTeaserImage.php
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types=1);
+
+namespace Werkl\OpenBlogware\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Defaults;
+use Shopware\Core\Framework\Migration\MigrationStep;
+use Shopware\Core\Framework\Uuid\Uuid;
+
+class Migration1744229687TranslatableTeaserImage extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1744229687;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $this->addColumnToTranslationTable($connection);
+        $this->migrateMediaIdToTranslationTable($connection);
+        $this->removeColumnFromTable($connection);
+    }
+
+    private function addColumnToTranslationTable(Connection $connection): void
+    {
+        $connection->executeStatement('
+            ALTER TABLE `werkl_blog_entries_translation`
+            ADD COLUMN `media_id` BINARY(16) DEFAULT NULL AFTER `language_id`;
+        ');
+    }
+
+    private function migrateMediaIdToTranslationTable(Connection $connection): void
+    {
+        $connection->executeStatement('
+            UPDATE `werkl_blog_entries_translation`
+            SET `media_id` = (
+                SELECT `media_id`
+                FROM `werkl_blog_entries`
+                WHERE `werkl_blog_entries`.`id` = `werkl_blog_entries_translation`.`werkl_blog_entries_id`
+            )
+            WHERE `werkl_blog_entries_translation`.`language_id` = :languageId;
+        ', [
+            'languageId' => Uuid::fromHexToBytes(Defaults::LANGUAGE_SYSTEM),
+        ]);
+    }
+
+    private function removeColumnFromTable(Connection $connection): void
+    {
+        $connection->executeStatement('
+            ALTER TABLE `werkl_blog_entries`
+            DROP COLUMN `media_id`;
+        ');
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -229,6 +229,8 @@
         </service>
 
         <service id="Werkl\OpenBlogware\Content\Blog\Subscriber\BlogSubscriber" >
+            <argument type="service" id="media.repository"/>
+
             <tag name="kernel.event_subscriber" />
         </service>
 
@@ -240,10 +242,6 @@
             <argument type="service" id="Shopware\Core\System\SystemConfig\SystemConfigService"/>
 
             <tag name="kernel.event_subscriber"/>
-        </service>
-
-        <service id="Werkl\OpenBlogware\Content\Blog\Subscriber\BlogSubscriber" >
-            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>


### PR DESCRIPTION
At the moment, the teaser image of a blog entry is not translatable.
In some cases you might want to use different images for each language, maybe because there is some text displayed on the image which should be shown in the correct language.

Edit: Additionally I've fixed ecs & phpstan errors.