### PR TITLE
fix: add missing .value to fullWidth config access

### DIFF
--- a/src/Resources/views/storefront/block/cms-block-blog-detail.html.twig
+++ b/src/Resources/views/storefront/block/cms-block-blog-detail.html.twig
@@ -1,7 +1,7 @@
 {% block block_werkl_blog_detail %}
     {% set element = block.slots.getSlot('blogDetail') %}
 
-    <div class="{% if element.config.fullWidth %}col-12{% elseif section and section.sizingMode === 'boxed' %}col-md-8 offset-md-2{% endif %}" data-cms-element-id="{{ element.id }}">
+    <div class="{% if element.config.fullWidth.value %}col-12{% elseif section and section.sizingMode === 'boxed' %}col-md-8 offset-md-2{% endif %}" data-cms-element-id="{{ element.id }}">
         {% sw_include '@Storefront/storefront/element/cms-element-' ~ element.type ~ '.html.twig' ignore missing %}
     </div>
 {% endblock %}


### PR DESCRIPTION
Fixes issue #46 - Missing attribute name value in cms-block-blog-detail.html.twig

The frontend template was accessing element.config.fullWidth directly, but Shopware CMS elements store config values in a nested 'value' property.

Changed from:
{% if element.config.fullWidth %}
to:
{% if element.config.fullWidth.value %}