### PR TITLE
Fix: Add /blog prefix to default SEO template

### DIFF
--- a/src/WerklOpenBlogware.php
+++ b/src/WerklOpenBlogware.php
@@ -386,7 +386,7 @@ class WerklOpenBlogware extends Plugin
     $existing = $repo->search($criteria, $context)->first();
 
     // Minimal funktionierendes Template (kein leerer String!)
-    $template = '{{ entry.translated.title }}';
+    $template = 'blog/{{ entry.translated.title }}';
 
     if ($existing === null) {
         $repo->create([[


### PR DESCRIPTION
So existing /blog URLs don't break after plugin update.

See: https://github.com/Werkstattl/OpenBlogware/pull/60#issuecomment-2789871806