### PR TITLE
fix: resolve criteria association warnings for blog author and suggest media

### DIFF
--- a/src/Content/SalesChannel/Suggest/ProductSuggestDecorated.php
+++ b/src/Content/SalesChannel/Suggest/ProductSuggestDecorated.php
@@ -71,7 +71,6 @@ class ProductSuggestDecorated extends AbstractProductSuggestRoute
         $criteria = new Criteria();
         $criteria->setTerm($term);
         $criteria->setLimit($limit);
-        $criteria->addAssociation('media');
         $criteria->addAssociation('tags');
         $criteria->addAssociation('blogCategories');
         $criteria->getAssociation('blogCategories')->addSorting(new FieldSorting('level', FieldSorting::ASCENDING));

--- a/src/Page/Blog/BlogPageLoader.php
+++ b/src/Page/Blog/BlogPageLoader.php
@@ -95,10 +95,9 @@ class BlogPageLoader
     private function loadBlogEntry(string $articleId, SalesChannelContext $context): BlogEntryEntity
     {
         $criteria = (new Criteria([$articleId]))
-            ->addAssociation('author.salutation')
+            ->addAssociation('blogAuthor.salutation')
             ->addAssociation('blogCategories')
             ->addAssociation('tags')
-            ->addAssociation('blogAuthor')
             ->addFilter(new BlogEntryActiveFilter($context->getSalesChannelId(), false));
         $this->eventDispatcher->dispatch(new BlogPageCriteriaEvent($articleId, $criteria, $context));
 


### PR DESCRIPTION
## Summary

Closes the warning spam reported in #83 by applying **Option A** (minimal, no behavior change), as agreed with @lacknere.

Two `addAssociation()` calls reference associations that don't exist on their target entities, producing Symfony `WARNING` log entries on every search-suggest request and blog detail load. Data still loads correctly via `BlogSubscriber::onBlogEntryLoaded`, so this is purely a log-noise fix.

## Changes

### `src/Page/Blog/BlogPageLoader.php`
- Rename `addAssociation('author.salutation')` → `addAssociation('blogAuthor.salutation')`
- Drop the now-redundant standalone `addAssociation('blogAuthor')`

`BlogEntryDefinition` exposes the relation as `blogAuthor` (FK `author_id`); `author` is a legacy alias that no longer resolves.

### `src/Content/SalesChannel/Suggest/ProductSuggestDecorated.php`
- Remove `addAssociation('media')`

Since the teaser image became translatable, `media_id` lives on `BlogEntryTranslationDefinition` as an `FkField` only — `AssociationField`s are not supported on `EntityTranslationDefinition`s (per @lacknere's clarification on #83). The hydrated media is now provided by `BlogSubscriber::onBlogEntryLoaded`, so the criteria-level association is both unresolvable and redundant.

## Impact observed in production logs

On a shop running 5.1.3 with regular search-suggest traffic:
- `~174` warnings/day from the suggest route
- `~18` warnings/day from blog detail loads

Both go to zero with this change. Frontend behavior unchanged.

## Test plan

- [ ] `/suggest` request with active search-box config: blog tile renders with image, no `WARNING` in `var/log/*.log`
- [ ] Blog detail page: author name + salutation render in meta, no `WARNING` in `var/log/*.log`

Refs: #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)